### PR TITLE
Fixed the missing .sh in install script line 289 './build' to './build.sh

### DIFF
--- a/install-tooloop-os.sh
+++ b/install-tooloop-os.sh
@@ -286,8 +286,7 @@ touch /opt/tooloop/settings-server/installed_app/.keep
 # For now:
 git clone https://github.com/Tooloop/Tooloop-Packages.git /home/tooloop/Tooloop-Packages
 cd /home/tooloop/Tooloop-Packages
-./build
-./update-packages
+./build.sh
 
 # Chown things to the tooloop user
 chown -R tooloop:tooloop /assets/


### PR DESCRIPTION
Fixed the missing .sh in install script line 289 './build' to './build.sh and removed update-packages, because there is no such script